### PR TITLE
fix: 25396-LambdaDatadogUpgrade: upgrading the cf stack for datadog

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -89,7 +89,7 @@ variable "log_exclude_at_match" {
 variable "dd_forwarder_template_version" {
   description = "Sets Datadog Forwarder version to use"
   type        = string
-  default     = "3.27.0"
+  default     = "latest"
 }
 
 variable "dd_forwarder_dd_site" {


### PR DESCRIPTION
a PR to upgrade the cloudformation stack version in terraform

<img width="1187" alt="image" src="https://github.com/YouLend/terraform-aws-datadog/assets/105635966/df55f564-05a6-4747-b8d4-5e992322f910">
